### PR TITLE
Fixed: `doctype 5` is deprecated, you must now use `doctype html` error 

### DIFF
--- a/examples/react-tut/index.jade
+++ b/examples/react-tut/index.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title React Tutorial in Reactive Coffee


### PR DESCRIPTION
Got this error while compiling examples. Patch fixes.
