### PR TITLE
Allow stabby-proc nesting syntax for rxt.tags DSL

### DIFF
--- a/src/reactive.coffee
+++ b/src/reactive.coffee
@@ -720,9 +720,16 @@ setDynProp = (elt, prop, val, xform = _.identity) ->
 
 rxt.mktag = mktag = (tag) ->
   (arg1, arg2) ->
-    # arguments are either (), (attrs: Object), (contents: Contents), or
-    # (attrs: Object, contents: Contents), where Contents is:
-    # string | Element | RawHtml | $ | Array | ObsCell | ObsArray
+    # arguments may be:
+    #   ()
+    #   (attrs: Object)
+    #   (contents: Contents)
+    #   (attrs: Object, contents: Contents)
+    # where Contents is:
+    #   string | Element | RawHtml | $ | Array | ObsCell | ObsArray
+    #
+    # if Contents is a function it will be evaluated, and expected to
+    #   return an allowable Contents instance
     [attrs, contents] =
       if not arg1? and not arg2?
         [{}, null]
@@ -730,10 +737,13 @@ rxt.mktag = mktag = (tag) ->
         [arg1, arg2]
       else if _.isString(arg1) or arg1 instanceof Element or
           arg1 instanceof RawHtml or arg1 instanceof $ or _.isArray(arg1) or
-          arg1 instanceof ObsCell or arg1 instanceof ObsArray
+          arg1 instanceof ObsCell or arg1 instanceof ObsArray or
+          arg1 instanceof Function
         [{}, arg1]
       else
         [arg1, null]
+
+    contents = contents.apply() if contents instanceof Function
 
     elt = $("<#{tag}/>")
     for name, value of _.omit(attrs, _.keys(specialAttrs))

--- a/test/spec/test_reactive.coffee
+++ b/test/spec/test_reactive.coffee
@@ -35,10 +35,11 @@ describe 'dependent cell', ->
     expect(-> dep.set(0)).toThrow()
 
 describe 'tag', ->
-  size = elt = null
+  size = elt = ul = li = button = header = null
   beforeEach ->
+    [ul, li, button, header] = [rxt.tags.ul, rxt.tags.li, rxt.tags.button, rxt.tags.header]
     size = rx.cell(10)
-    elt = rxt.tags.header {
+    elt = header {
       class: 'my-class'
       style: bind -> "font-size: #{size.get()}px"
       id: 'my-elt'
@@ -46,7 +47,7 @@ describe 'tag', ->
       init: -> @data('foo', 'bar')
     }, bind -> [
       'hello world'
-      rxt.tags.button ['click me']
+      button ['click me']
     ]
   it 'should have the right tag', ->
     expect(elt.is('header')).toBe(true)
@@ -71,6 +72,26 @@ describe 'tag', ->
   it 'should not have special attrs set', ->
     expect(elt.attr('init')).toBe(undefined)
     expect(elt.attr('click')).toBe(undefined)
+
+  describe 'creation of nodes', ->
+    describe 'stabby proc style', ->
+      it 'should be usable', ->
+        testlist = div ->
+          ul ['wontoo'].map (item) ->
+            li item
+        expect(testlist.html()).toBe('<ul><li>wontoo</li></ul>')
+
+      it 'should allow nesting of tags', ->
+        testlist = div ->
+          ul ->
+            li -> 'wontoo'
+        expect(testlist.html()).toBe('<ul><li>wontoo</li></ul>')
+
+      it 'should allow tag hash', ->
+        testlist = div ->
+          ul = ul {class:'foo'}, ->
+            li -> 'wontoo'
+        expect(ul.hasClass('foo')).toBe(true)
 
 describe 'rxt of observable array', ->
   xs = elt = null


### PR DESCRIPTION
Yang, libs like Teacup https://github.com/goodeggs/teacup-rails have a syntax for nesting content which I rather like and thought others might as well. If you like this syntax being in reactive, here's a possible patch. Do you anticipate any problem with rx.binds being in these ?
