### PR TITLE
Provided selector-style syntax for initializing tags classes and ids

### DIFF
--- a/src/reactive.coffee
+++ b/src/reactive.coffee
@@ -718,17 +718,31 @@ setDynProp = (elt, prop, val, xform = _.identity) ->
   else
     setProp(elt, prop, xform(val))
 
+rxt.mkAtts = mkAtts = (attstr) ->
+  do(atts = {}) ->
+    match = attstr.match /[#](\w+)/
+    if match
+      atts.id = match[1]
+    atts.class = (cls.replace(/^\./, '') for cls in attstr.match(/\.\w+/g)).join(' ')
+    atts
+
 rxt.mktag = mktag = (tag) ->
   (arg1, arg2) ->
-    # arguments are either (), (attrs: Object), (contents: Contents), or
-    # (attrs: Object, contents: Contents), where Contents is:
-    # string | Element | RawHtml | $ | Array | ObsCell | ObsArray
+    # arguments may be:
+    #   ()
+    #   (attrs: Object)
+    #   (contents: Contents)
+    #   (attrs: Object, contents: Contents)
+    # where Contents is:
+    #   string | Element | RawHtml | $ | Array | ObsCell | ObsArray
     [attrs, contents] =
       if not arg1? and not arg2?
         [{}, null]
-      else if arg2?
+      else if arg1 instanceof Object and arg2?
         [arg1, arg2]
-      else if _.isString(arg1) or arg1 instanceof Element or
+      else if _.isString(arg1) and arg2?
+        [mkAtts(arg1), arg2]
+      else if not arg2? and _.isString(arg1) or arg1 instanceof Element or
           arg1 instanceof RawHtml or arg1 instanceof $ or _.isArray(arg1) or
           arg1 instanceof ObsCell or arg1 instanceof ObsArray
         [{}, arg1]

--- a/test/spec/test_reactive.coffee
+++ b/test/spec/test_reactive.coffee
@@ -35,42 +35,50 @@ describe 'dependent cell', ->
     expect(-> dep.set(0)).toThrow()
 
 describe 'tag', ->
-  size = elt = null
-  beforeEach ->
-    size = rx.cell(10)
-    elt = rxt.tags.header {
-      class: 'my-class'
-      style: bind -> "font-size: #{size.get()}px"
-      id: 'my-elt'
-      click: ->
-      init: -> @data('foo', 'bar')
-    }, bind -> [
-      'hello world'
-      rxt.tags.button ['click me']
-    ]
-  it 'should have the right tag', ->
-    expect(elt.is('header')).toBe(true)
-  it 'should have the set attributes', ->
-    expect(elt.prop('class')).toBe('my-class')
-    expect(elt.attr('style')).toBe('font-size: 10px')
-    expect(elt.prop('id')).toBe('my-elt')
-    expect(elt.hasClass('my-class')).toBe(true)
-    expect(elt.css('font-size')).toBe('10px')
-    expect(elt.data('foo')).toBe('bar')
-  it 'should update attrs in response to size changes', ->
-    size.set(9)
-    expect(elt.attr('style')).toBe('font-size: 9px')
-    expect(elt.css('font-size')).toBe('9px')
-  it 'should have the given child contents', ->
-    cont = elt.contents()
-    expect(cont.length).toBe(2)
-    expect(cont[0]).toEqual(jasmine.any(Text))
-    expect(cont[0].textContent).toBe('hello world')
-    expect(cont.last().is('button')).toBe(true)
-    expect(cont.last().text()).toBe('click me')
-  it 'should not have special attrs set', ->
-    expect(elt.attr('init')).toBe(undefined)
-    expect(elt.attr('click')).toBe(undefined)
+  describe 'object creation', ->
+    size = elt = null
+    beforeEach ->
+      size = rx.cell(10)
+      elt = rxt.tags.header {
+        class: 'my-class'
+        style: bind -> "font-size: #{size.get()}px"
+        id: 'my-elt'
+        click: ->
+        init: -> @data('foo', 'bar')
+      }, bind -> [
+        'hello world'
+        rxt.tags.button ['click me']
+      ]
+    it 'should have the right tag', ->
+      expect(elt.is('header')).toBe(true)
+    it 'should have the set attributes', ->
+      expect(elt.prop('class')).toBe('my-class')
+      expect(elt.attr('style')).toBe('font-size: 10px')
+      expect(elt.prop('id')).toBe('my-elt')
+      expect(elt.hasClass('my-class')).toBe(true)
+      expect(elt.css('font-size')).toBe('10px')
+      expect(elt.data('foo')).toBe('bar')
+    it 'should update attrs in response to size changes', ->
+      size.set(9)
+      expect(elt.attr('style')).toBe('font-size: 9px')
+      expect(elt.css('font-size')).toBe('9px')
+    it 'should have the given child contents', ->
+      cont = elt.contents()
+      expect(cont.length).toBe(2)
+      expect(cont[0]).toEqual(jasmine.any(Text))
+      expect(cont[0].textContent).toBe('hello world')
+      expect(cont.last().is('button')).toBe(true)
+      expect(cont.last().text()).toBe('click me')
+    it 'should not have special attrs set', ->
+      expect(elt.attr('init')).toBe(undefined)
+      expect(elt.attr('click')).toBe(undefined)
+
+  describe 'attribute id and class parsing', ->
+    it 'should be creatable with a shortcut syntax for attrs object', ->
+      elt = div '#zip.zap.zop', 'text'
+      expect(elt.prop('id')).toBe('zip')
+      expect(elt.hasClass('zap')).toBe(true)
+      expect(elt.hasClass('zop')).toBe(true)
 
 describe 'rxt of observable array', ->
   xs = elt = null


### PR DESCRIPTION
..ala #id.cls.cls2
- cleaned up comment and conditionals
