### PR TITLE
Fix for #id.cls1 parsing when no classes present

### DIFF
--- a/src/reactive.coffee
+++ b/src/reactive.coffee
@@ -716,9 +716,11 @@ rxFactory = (_, _str, $) ->
 
     rxt.mkAtts = mkAtts = (attstr) ->
       do(atts = {}) ->
-        match = attstr.match /[#](\w+)/
-        atts.id = match[1] if match
-        atts.class = (cls.replace(/^\./, '') for cls in attstr.match(/\.\w+/g)).join(' ')
+        id = attstr.match /[#](\w+)/
+        atts.id = id[1] if id
+        classes = attstr.match(/\.\w+/g)
+        if classes
+          atts.class = (cls.replace(/^\./, '') for cls in classes).join(' ')
         atts
     
 

--- a/test/spec/test_reactive.coffee
+++ b/test/spec/test_reactive.coffee
@@ -74,7 +74,10 @@ describe 'tag', ->
       expect(elt.attr('click')).toBe(undefined)
 
   describe 'attribute id and class parsing', ->
-    it 'should be creatable with a shortcut syntax for attrs object', ->
+    it 'should be creatable with #id', ->
+      elt = div '#zip', 'text'
+      expect(elt.prop('id')).toBe('zip')
+    it 'should be creatable with #id.cls1.cls2', ->
       elt = div '#zip.zap.zop', 'text'
       expect(elt.prop('id')).toBe('zip')
       expect(elt.hasClass('zap')).toBe(true)


### PR DESCRIPTION
Silly mistake corrected.
