### PR TITLE
Build Reactive on Travis CI box and get nice Build Passing badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '0.10'
 before_install:
+  - npm install -g grunt-cli
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'reactive-coffee' ]; then cd .. && eval "mv $currentfolder reactive-coffee" && cd reactive-coffee; fi
-
+install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '0.10'
 before_install:
-  - npm install -g grunt-cli
+  - npm install -g grunt-cli bower
   - bower install
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'reactive-coffee' ]; then cd .. && eval "mv $currentfolder reactive-coffee" && cd reactive-coffee; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '0.10'
 before_install:
   - npm install -g grunt-cli
+  - bower install
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'reactive-coffee' ]; then cd .. && eval "mv $currentfolder reactive-coffee" && cd reactive-coffee; fi
 install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '0.10'
+before_install:
+  - currentfolder=${PWD##*/}
+  - if [ "$currentfolder" != 'reactive-coffee' ]; then cd .. && eval "mv $currentfolder reactive-coffee" && cd reactive-coffee; fi
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-reactive.coffee
+reactive.coffee [![Build Status](https://secure.travis-ci.org/chicagogrooves/reactive-coffee.png?branch=master)](https://travis-ci.org/chicagogrooves/reactive-coffee)
 ===============
 
 A lightweight CoffeeScript library/DSL for [reactive programming] and for

--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ rationale][design].
 [tutorial]: http://yang.github.io/reactive-coffee/tutorial.html
 [design]: http://yang.github.io/reactive-coffee/design.html
 [related]: http://yang.github.io/reactive-coffee/related.html
+


### PR DESCRIPTION
Right now this builds off of the chicagogrooves' Travis CI account.. The badge displayed in the readme visible here (https://github.com/chicagogrooves/reactive-coffee/)  shows the current build status and gives new visitors confidence in the library.

The only thing needed to change for a new Travis CI account would be to change the link in the README.
