### PR TITLE
Compile with sourcemaps for easier debugging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,9 @@ module.exports = function (grunt) {
     },
     coffee: {
       dist: {
+        options: {
+          sourceMap: true
+        },
         files: [{
           expand: true,
           cwd: '<%= yeoman.src %>',


### PR DESCRIPTION
Surprisingly this works with only CS 1.6.3, i thought it was a >= 1.7 feature.. Stepping through the original source is much nicer, I find.
